### PR TITLE
fix: correct first word in ZEN (#5)

### DIFF
--- a/ZEN.md
+++ b/ZEN.md
@@ -2,7 +2,7 @@
 ```txt
 Butiful is better than ugley.
 Eksplicit is beter than implisit.
-Simpl is beter than compleks.
+Simple is beter than compleks.
 Compleks is beter than komplicated.
 Flat is better than nested.
 Sparse is better than dense.


### PR DESCRIPTION
Sorry, it's invalid name of first commit, it should be: corrected string in ZEN(#5)
So, in the second commit I leave only one corrected word 